### PR TITLE
Use 'zmprov' (the correct command name) instead of 'zmprove' (wrong)

### DIFF
--- a/Zimbra 8.8.15 zmprove ca command
+++ b/Zimbra 8.8.15 zmprove ca command
@@ -2,7 +2,7 @@
 >
 > [Suggested description]
 > Zimbra Collaboration Open Source 8.8.15 does not encrypt the initial-login
-> randomly created password (from the "zmprove ca" command). It is visible
+> randomly created password (from the "zmprov ca" command). It is visible
 > in cleartext on port UDP 514 (aka the
 > Syslog port).
 > 
@@ -24,7 +24,7 @@
 > ------------------------------------------
 > 
 > [Affected Component]
-> "zimbra/zmprove ca" command
+> "zimbra/zmprov ca" command
 > 
 > ------------------------------------------
 > 
@@ -49,10 +49,10 @@
 > ------------------------------------------
 > 
 > [Attack Vectors]
-> when an user created with "zmprove ca" command in zimbra, a random
+> when an user created with "zmprov ca" command in zimbra, a random
 > password will generate with it. but, when an eavesdropper listening to
 > port UDP 514 aka Syslog port, the password can be seen in clear text
-> with "COMMAND=zimbra/zmprove ca username and password" format. admin
+> with "COMMAND=zimbra/zmprov ca username and password" format. admin
 > can active most change password option but it's not enough.
 > 
 > ------------------------------------------


### PR DESCRIPTION
Please use at least the correct command name: `zmprov`. Meanwhile this advisory is also known as [CVE-2022-32294](https://www.cve.org/CVERecord?id=CVE-2022-32294).

Aside of this, I'm _unable_ to reproduce the issue. And unfortunately your description how to reproduce this possible security flaw is incomplete. Based on the official Zimbra administration guidelines, I assumed the following steps:

1. assumed step:
```
# su - zimbra
$ zmprov ca tux@example.net ""
5db256d6-9bdc-45ac-b2da-04bd42018406
$ 
```
2. assumed step: Initial random password should be revealed in `/var/log/secure` (RHEL/Rocky Linux, or where ever `sudo` calls are logged) – but `zmprov` by itself does not call `sudo` at all, and I can _not_ find any hint about a password for my above example user `tux@example.net` in any syslog file or elsewhere within the syslog stack.

Further on: _If_ this security flaw really exists, but was just accidentially described incompletely, it mainly applies by default only to Zimbra multi-server setups with remote syslog, or to regular setups with manually configured remote syslog. On default Zimbra single-server setups without any manually configured remote syslog, the password is _not_ transmitted to foreign systems.

Most likely the `sudo` calls in your screenshot (copied in below) are caused by a third-party application, but not by Zimbra.

![image](https://user-images.githubusercontent.com/10982488/212358466-085cf355-a3bc-420a-af95-085a8ec4722e.png)